### PR TITLE
[CSS] show table header on scroll

### DIFF
--- a/templates/stocks.html
+++ b/templates/stocks.html
@@ -1,6 +1,18 @@
 {% extends "base.html" %}
 
 {% block content %}
+<style>
+  #stocks-table thead tr:nth-child(1) {
+    padding-top:
+  }
+  #stocks-table thead tr:nth-child(1) th {
+    position: sticky;
+    top: 43px;
+    padding-top: 0.92857143em;
+    background-color: #F9FAFB;
+  }
+</style>
+
 <h3 class="ui header">
   <div class="content">
     Snowball
@@ -19,7 +31,7 @@
 </form>
 <div class="ui grid">
     <div class="sixteen wide column">
-        <table class="ui very basic compact table">
+        <table class="ui very basic compact table" id="stocks-table">
             <thead>
             <tr>
                 <th>종목코드</th>


### PR DESCRIPTION
This creates a 'sticky' table header on scroll.

Notice the header being visible while the scrollbar is somewhere in the middle.

![image](https://user-images.githubusercontent.com/52015/40869750-ec1600de-665a-11e8-9d3d-0969f29ad003.png)

Besides adding a `position: sticky;` to `table thead trow th`,
- add `id="stocks-table"` to specify the table
- add `background-color: #F9FAFB;` to distinguish with the content.
- add `top: 43px` to lay the position below the gnb header.


